### PR TITLE
parser: support else statements

### DIFF
--- a/phpast/samples/if.php
+++ b/phpast/samples/if.php
@@ -1,0 +1,7 @@
+<?php
+
+if($foo) {
+    return $foo;
+} else {
+    return $foo;
+}

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -170,6 +170,7 @@ pub enum Statement {
     If {
         condition: Expression,
         then: Block,
+        r#else: Option<Block>
     },
     Return {
         value: Option<Expression>,


### PR DESCRIPTION
Added parser support for the `else` branch inside if statements.

```php
<?php

if($foo) {
    return $foo;
} else {
    return $foo;
}
```