### PR TITLE
Feat/else if statements

### DIFF
--- a/phpast/samples/if.php
+++ b/phpast/samples/if.php
@@ -2,6 +2,10 @@
 
 if($foo) {
     return $foo;
+} elseif($foo) {
+    return $foo;
+} elseif($foo) {
+    return $foo;
 } else {
     return $foo;
 }

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -176,6 +176,7 @@ pub enum Statement {
     If {
         condition: Expression,
         then: Block,
+        else_ifs: Vec<ElseIf>,
         r#else: Option<Block>
     },
     Return {
@@ -271,4 +272,10 @@ impl From<TokenKind> for InfixOp {
             _ => unreachable!()
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ElseIf {
+    pub condition: Expression,
+    pub body: Block,
 }

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1031,7 +1031,7 @@ impl Display for ParseError {
 #[cfg(test)]
 mod tests {
     use trunk_lexer::Lexer;
-    use crate::{Statement, Param, Expression, ast::{InfixOp}, Type, Identifier};
+    use crate::{Statement, Param, Expression, ast::{InfixOp, ElseIf}, Type, Identifier};
     use super::Parser;
 
     macro_rules! function {
@@ -1290,6 +1290,29 @@ mod tests {
                         Statement::Return { value: Some(Expression::Variable("foo".into())) }
                     ],
                     else_ifs: vec![],
+                    r#else: Some(vec![
+                        Statement::Return { value: Some(Expression::Variable("foo".into())) }
+                    ])
+                },
+        ]);
+    }
+
+    #[test]
+    fn if_elseif_else_statement() {
+        assert_ast("<?php if($foo) { return $foo; } elseif($foo) { return $foo; } else { return $foo; }", &[
+                Statement::If {
+                    condition: Expression::Variable("foo".into()),
+                    then: vec![
+                        Statement::Return { value: Some(Expression::Variable("foo".into())) }
+                    ],
+                    else_ifs: vec![
+                        ElseIf {
+                            condition: Expression::Variable("foo".into()),
+                            body: vec![
+                                Statement::Return { value: Some(Expression::Variable("foo".into())) }
+                            ]
+                        }
+                    ],
                     r#else: Some(vec![
                         Statement::Return { value: Some(Expression::Variable("foo".into())) }
                     ])


### PR DESCRIPTION
Adds support for `elseif` to parser.
```php
<?php

if($foo) {
    return $foo;
} elseif($foo) {
    return $foo;
} elseif($foo) {
    return $foo;
} else {
    return $foo;
}
```