### PR TITLE
Remove nightly Rust requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This project requires nightly Rust due to use of if-let chaining (see https://github.com/rust-lang/rust/issues/53667). It's a nice quality-of-life change that I'm also looking forward to using once it's stable, but I found that requiring nightly presented a small barrier to me when I tried to build and run this project.

The first commit of this PR runs rustfmt on the lexer source, since my editor did it automatically. I hope this is okay, but if there's another format I should use instead I'd be happy to make changes.