### PR TITLE
Add support for block statements

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -271,6 +271,9 @@ pub enum Statement {
         name: Identifier,
         value: Option<Expression>,
     },
+    Block {
+        body: Block,
+    },
     Noop,
 }
 

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -893,6 +893,12 @@ impl Parser {
                     finally,
                 }
             }
+            TokenKind::LeftBrace => {
+                self.next();
+                let body = self.block(&TokenKind::RightBrace)?;
+                self.rbrace()?;
+                Statement::Block { body }
+            }
             _ => {
                 let expr = self.expression(0)?;
 
@@ -2953,6 +2959,19 @@ mod tests {
                     ],
                 },
                 body: vec![],
+            }],
+        );
+    }
+
+    #[test]
+    fn block() {
+        assert_ast("<?php {}", &[Statement::Block { body: vec![] }]);
+        assert_ast(
+            "<?php { $a; }",
+            &[Statement::Block {
+                body: vec![Statement::Expression {
+                    expr: Expression::Variable { name: "a".into() },
+                }],
             }],
         );
     }


### PR DESCRIPTION
PHP allows blocks to be added anywhere in a statement context. eg:

```php
<?php
{}
{
    echo "We're inside a block\n";
}
```