### PR TITLE
Fix off-by-one error when lexing variable names

### DIFF
--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -350,7 +350,7 @@ impl Lexer {
 
                 while let Some(n) = self.peek {
                     match n {
-                        '0'..='9' if buffer.len() > 1 => {
+                        '0'..='9' if buffer.len() > 0 => {
                             self.col += 1;
                             buffer.push(n);
                             self.next();
@@ -1017,13 +1017,14 @@ function"#,
     #[test]
     fn vars() {
         assert_tokens(
-            "<?php $one $_one $One $one_one",
+            "<?php $one $_one $One $one_one $a1",
             &[
                 open!(),
                 var!("one"),
                 var!("_one"),
                 var!("One"),
                 var!("one_one"),
+                var!("a1"),
             ],
         );
     }


### PR DESCRIPTION
This meant a variable named $a1 was treated as two separate tokens: the variable $a, and an integer literal.