### PR TITLE
Parse include and include_once

### DIFF
--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -846,6 +846,8 @@ fn identifier_to_keyword(ident: &str) -> Option<TokenKind> {
         "foreach" => TokenKind::Foreach,
         "function" => TokenKind::Function,
         "if" => TokenKind::If,
+        "include" => TokenKind::Include,
+        "include_once" => TokenKind::IncludeOnce,
         "implements" => TokenKind::Implements,
         "interface" => TokenKind::Interface,
         "instanceof" => TokenKind::Instanceof,

--- a/trunk_lexer/src/token.rs
+++ b/trunk_lexer/src/token.rs
@@ -90,6 +90,8 @@ pub enum TokenKind {
     Identifier(String),
     If,
     Implements,
+    Include,
+    IncludeOnce,
     Increment,
     InlineHtml(String),
     Instanceof,

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -144,6 +144,26 @@ pub struct StaticVar {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
+pub enum IncludeKind {
+    Include,
+    IncludeOnce,
+    Require,
+    RequireOnce,
+}
+
+impl From<&TokenKind> for IncludeKind {
+    fn from(k: &TokenKind) -> Self {
+        match k {
+            TokenKind::Include => IncludeKind::Include,
+            TokenKind::IncludeOnce => IncludeKind::IncludeOnce,
+            TokenKind::Require => IncludeKind::Require,
+            TokenKind::RequireOnce => IncludeKind::RequireOnce,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum Statement {
     InlineHtml(String),
     Static {
@@ -166,10 +186,8 @@ pub enum Statement {
         value_var: Expression,
         body: Block,
     },
-    Require {
-        path: Expression,
-    },
-    RequireOnce {
+    Include {
+        kind: IncludeKind,
         path: Expression,
     },
     Var {


### PR DESCRIPTION
This also refactors all for include operations to share a `Statement::Include` variant, with a new `IncludeKind` type, as implementing four separate variants felt like too much repetition.