### PR TITLE
parser: support for error suppress expressions

### DIFF
--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -167,6 +167,11 @@ impl Lexer {
         let char = self.current.unwrap();
 
         let kind = match char {
+            '@' => {
+                self.col += 1;
+
+                TokenKind::At
+            },
             '!' => {
                 self.col += 1;
 

--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -171,7 +171,7 @@ impl Lexer {
                 self.col += 1;
 
                 TokenKind::At
-            },
+            }
             '!' => {
                 self.col += 1;
 

--- a/trunk_lexer/src/token.rs
+++ b/trunk_lexer/src/token.rs
@@ -17,6 +17,7 @@ pub enum TokenKind {
     ArrayCast,
     Arrow,
     NullsafeArrow,
+    At,
     As,
     Asterisk,
     Attribute,

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -376,6 +376,9 @@ pub struct Use {
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum Expression {
     Static,
+    ErrorSuppress {
+        expr: Box<Self>,
+    },
     Increment {
         value: Box<Self>,
     },

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1993,6 +1993,7 @@ fn is_prefix(op: &TokenKind) -> bool {
             | TokenKind::BoolCast
             | TokenKind::IntCast
             | TokenKind::DoubleCast
+            | TokenKind::At
     )
 }
 
@@ -2003,8 +2004,9 @@ fn prefix_binding_power(op: &TokenKind) -> u8 {
         | TokenKind::BoolCast
         | TokenKind::IntCast
         | TokenKind::DoubleCast => 101,
-        TokenKind::Minus => 100,
-        TokenKind::Bang => 99,
+        TokenKind::At => 16,
+        TokenKind::Minus => 99,
+        TokenKind::Bang => 98,
         _ => unreachable!(),
     }
 }
@@ -2025,6 +2027,7 @@ fn prefix(op: &TokenKind, rhs: Expression) -> Expression {
             kind: op.into(),
             value: Box::new(rhs),
         },
+        TokenKind::At => Expression::ErrorSuppress { expr: Box::new(rhs) },
         _ => unreachable!(),
     }
 }
@@ -3155,6 +3158,20 @@ mod tests {
             "<?php ?> <html>",
             &[Statement::InlineHtml(" <html>".into())],
         );
+    }
+
+    #[test]
+    fn error_suppress() {
+        assert_ast("<?php @hello();", &[
+            expr!(Expression::ErrorSuppress {
+                expr: Box::new(Expression::Call {
+                    target: Box::new(Expression::Identifier {
+                        name: "hello".into()
+                    }),
+                    args: vec![],
+                }),
+            })
+        ]);
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -2027,7 +2027,9 @@ fn prefix(op: &TokenKind, rhs: Expression) -> Expression {
             kind: op.into(),
             value: Box::new(rhs),
         },
-        TokenKind::At => Expression::ErrorSuppress { expr: Box::new(rhs) },
+        TokenKind::At => Expression::ErrorSuppress {
+            expr: Box::new(rhs),
+        },
         _ => unreachable!(),
     }
 }
@@ -3162,16 +3164,17 @@ mod tests {
 
     #[test]
     fn error_suppress() {
-        assert_ast("<?php @hello();", &[
-            expr!(Expression::ErrorSuppress {
+        assert_ast(
+            "<?php @hello();",
+            &[expr!(Expression::ErrorSuppress {
                 expr: Box::new(Expression::Call {
                     target: Box::new(Expression::Identifier {
                         name: "hello".into()
                     }),
                     args: vec![],
                 }),
-            })
-        ]);
+            })],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {


### PR DESCRIPTION
Related to #19.

The support for `@` expressions is limited with these changes and there will likely be precedence problems. Those will need to be fixed at a later date perhaps using the `nikic/php-parser` tests.