### PR TITLE
lexer: fix nullsafe arrow token skipping too many characters

### DIFF
--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -237,7 +237,7 @@ impl Lexer {
                     TokenKind::QuestionColon
                 } else if self.try_read("->") {
                     self.col += 1;
-                    self.skip(3);
+                    self.skip(2);
                     TokenKind::NullsafeArrow
                 } else {
                     TokenKind::Question

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -3179,9 +3179,13 @@ mod tests {
 
     #[test]
     fn nullsafe_operator() {
-        assert_ast("<?php $a?->b;", &[
-            expr!(Expression::NullsafePropertyFetch { target: Box::new(Expression::Variable { name: "a".into() }), property: Box::new(Expression::Identifier { name: "b".into() }) })
-        ]);
+        assert_ast(
+            "<?php $a?->b;",
+            &[expr!(Expression::NullsafePropertyFetch {
+                target: Box::new(Expression::Variable { name: "a".into() }),
+                property: Box::new(Expression::Identifier { name: "b".into() })
+            })],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -3177,6 +3177,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn nullsafe_operator() {
+        assert_ast("<?php $a?->b;", &[
+            expr!(Expression::NullsafePropertyFetch { target: Box::new(Expression::Variable { name: "a".into() }), property: Box::new(Expression::Identifier { name: "b".into() }) })
+        ]);
+    }
+
     fn assert_ast(source: &str, expected: &[Statement]) {
         let mut lexer = Lexer::new(None);
         let tokens = lexer.tokenize(source).unwrap();


### PR DESCRIPTION
Closes #48.

The lexer was skipping 1 too many characters when tokenising the code - if the property name was more than 1 character long this would have been more obvious.

Test case added to the parser to ensure it continues working.