### PR TITLE
parser: support catch conditions without variables

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -343,7 +343,7 @@ pub struct Case {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Catch {
     pub types: Vec<Identifier>,
-    pub var: Expression,
+    pub var: Option<Expression>,
     pub body: Block,
 }
 


### PR DESCRIPTION
Closes #44.

Also adds missing test coverage for:
* Try with a single catch
* Try with a single catch and no variable binding
* Try with multiple catches
* Try with catch and finally
* Try without catch and finally