### PR TITLE
parser: support top-level constants

### DIFF
--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -925,6 +925,20 @@ impl Parser {
                 self.rbrace()?;
                 Statement::Block { body }
             }
+            TokenKind::Const => {
+                self.next();
+
+                // TODO: Support defining multiple constants in one go.
+                let name = self.ident()?;
+
+                expect!(self, TokenKind::Equals, "expected =");
+
+                let value = self.expression(0)?;
+
+                self.semi()?;
+
+                Statement::Constant { name: name.into(), value, flags: vec![] }
+            },
             _ => {
                 let expr = self.expression(0)?;
 
@@ -3273,6 +3287,13 @@ mod tests {
                 finally: Some(vec![]),
             }],
         );
+    }
+
+    #[test]
+    fn top_level_constant() {
+        assert_ast("<?php const FOO = 1;", &[
+            Statement::Constant { name: "FOO".into(), value: Expression::Int { i: 1 }, flags: vec![] }
+        ]);
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -937,8 +937,12 @@ impl Parser {
 
                 self.semi()?;
 
-                Statement::Constant { name: name.into(), value, flags: vec![] }
-            },
+                Statement::Constant {
+                    name: name.into(),
+                    value,
+                    flags: vec![],
+                }
+            }
             _ => {
                 let expr = self.expression(0)?;
 
@@ -3291,9 +3295,14 @@ mod tests {
 
     #[test]
     fn top_level_constant() {
-        assert_ast("<?php const FOO = 1;", &[
-            Statement::Constant { name: "FOO".into(), value: Expression::Int { i: 1 }, flags: vec![] }
-        ]);
+        assert_ast(
+            "<?php const FOO = 1;",
+            &[Statement::Constant {
+                name: "FOO".into(),
+                value: Expression::Int { i: 1 },
+                flags: vec![],
+            }],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {


### PR DESCRIPTION
Initial work towards #45.

Currently only supports defining a single constant, still needs to support multiple constants in the same statement but that will require larger changes to the `Statement` node since classes share the same one (probably not a good idea, the class should probably use `ClassConstant` instead).