### PR TITLE
fix: support empty array items

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -388,6 +388,7 @@ pub struct Use {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
     Static,
+    Empty,
     ErrorSuppress {
         expr: Box<Self>,
     },

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1505,6 +1505,12 @@ impl Parser {
                 self.skip_comments();
 
                 while self.current.kind != TokenKind::RightBracket {
+                    if self.current.kind == TokenKind::Comma {
+                        items.push(ArrayItem { key: None, value: Expression::Empty });
+                        self.next();
+                        continue;
+                    }
+
                     let mut key = None;
                     let mut value = self.expression(0)?;
 
@@ -3419,6 +3425,30 @@ mod tests {
                 }],
             }],
         );
+    }
+
+    #[test]
+    fn array_empty_items() {
+        assert_ast("<?php [1, 2, , 4];", &[
+            expr!(Expression::Array { items: vec![
+                ArrayItem {
+                    key: None,
+                    value: Expression::Int { i: 1 },
+                },
+                ArrayItem {
+                    key: None,
+                    value: Expression::Int { i: 2 },
+                },
+                ArrayItem {
+                    key: None,
+                    value: Expression::Empty,
+                },
+                ArrayItem {
+                    key: None,
+                    value: Expression::Int { i: 4 },
+                },
+            ] })
+        ])
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1506,7 +1506,10 @@ impl Parser {
 
                 while self.current.kind != TokenKind::RightBracket {
                     if self.current.kind == TokenKind::Comma {
-                        items.push(ArrayItem { key: None, value: Expression::Empty });
+                        items.push(ArrayItem {
+                            key: None,
+                            value: Expression::Empty,
+                        });
                         self.next();
                         continue;
                     }
@@ -3429,26 +3432,29 @@ mod tests {
 
     #[test]
     fn array_empty_items() {
-        assert_ast("<?php [1, 2, , 4];", &[
-            expr!(Expression::Array { items: vec![
-                ArrayItem {
-                    key: None,
-                    value: Expression::Int { i: 1 },
-                },
-                ArrayItem {
-                    key: None,
-                    value: Expression::Int { i: 2 },
-                },
-                ArrayItem {
-                    key: None,
-                    value: Expression::Empty,
-                },
-                ArrayItem {
-                    key: None,
-                    value: Expression::Int { i: 4 },
-                },
-            ] })
-        ])
+        assert_ast(
+            "<?php [1, 2, , 4];",
+            &[expr!(Expression::Array {
+                items: vec![
+                    ArrayItem {
+                        key: None,
+                        value: Expression::Int { i: 1 },
+                    },
+                    ArrayItem {
+                        key: None,
+                        value: Expression::Int { i: 2 },
+                    },
+                    ArrayItem {
+                        key: None,
+                        value: Expression::Empty,
+                    },
+                    ArrayItem {
+                        key: None,
+                        value: Expression::Int { i: 4 },
+                    },
+                ]
+            })],
+        )
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {


### PR DESCRIPTION
Closes #59.

I was a little hesitant to support this since at runtime, arrays aren't allowed to have empty items (it's just a parser detail), but if PHP-Parser supports it we should too.