### PR TITLE
feature: support defining multiple constants in one statement

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -206,6 +206,9 @@ pub enum Statement {
         flags: Vec<PropertyFlag>,
     },
     Constant {
+        constants: Vec<Constant>,
+    },
+    ClassConstant {
         name: Identifier,
         value: Expression,
         flags: Vec<ConstFlag>,
@@ -304,6 +307,12 @@ pub enum Statement {
         body: Block,
     },
     Noop,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Constant {
+    pub name: Identifier,
+    pub value: Expression,
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Closes #45.

Refactored out `Constant` variant and now have a separate one for classes to use (`ClassConstant`).