### PR TITLE
Lexer lookahead refactor

### DIFF
--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -797,26 +797,13 @@ impl Lexer {
         self.state = state;
     }
 
-    fn char_at(&self, idx: usize) -> Option<&u8> {
-        self.chars.get(idx)
-    }
-
     fn try_read(&self, search: &'static [u8]) -> bool {
         if self.current.is_none() || self.peek.is_none() {
             return false;
         }
 
         let start = self.cursor.saturating_sub(1);
-        let mut buffer = Vec::new();
-
-        for i in 0..search.len() {
-            match self.char_at(start + i) {
-                Some(char) => buffer.push(*char),
-                _ => return false,
-            };
-        }
-
-        buffer == search
+        self.chars[start..].starts_with(search)
     }
 
     fn skip(&mut self, count: usize) {

--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -122,7 +122,7 @@ impl Lexer {
     }
 
     fn scripting(&mut self) -> Result<Token, LexerError> {
-        let kind = match self.peek() {
+        let kind = match self.peek_buf() {
             [b'@', ..] => {
                 self.next();
                 self.col += 1;
@@ -310,7 +310,7 @@ impl Lexer {
                 let mut buffer = vec![b'/'];
 
                 while self.current.is_some() {
-                    match self.peek() {
+                    match self.peek_buf() {
                         [b'*', b'/', ..] => {
                             self.col += 2;
                             buffer.extend_from_slice(b"*/");
@@ -732,12 +732,12 @@ impl Lexer {
         self.state = state;
     }
 
-    fn peek(&self) -> &[u8] {
+    fn peek_buf(&self) -> &[u8] {
         &self.chars[self.cursor..]
     }
 
     fn try_read(&self, search: &'static [u8]) -> bool {
-        self.peek().starts_with(search)
+        self.peek_buf().starts_with(search)
     }
 
     fn skip(&mut self, count: usize) {


### PR DESCRIPTION
This re-works the lexer to use a buffer (`peek_buf` method) for lookahead instead of a single byte. This allows us to use one big pattern match for most things instead of having sub-branches within each case.

There's definitely a chance I've broken something, but all the existing tests pass.

I've also pulled out some of the larger cases into separate methods and factored out common number tokenization logic.

I really want to re-work how the column and line tracking is done but when I tried I ended up going down a rabbit hole, and will look at that as a separate piece.