### PR TITLE
parser/lexer: support __halt_compiler token

### DIFF
--- a/trunk_lexer/src/token.rs
+++ b/trunk_lexer/src/token.rs
@@ -11,6 +11,7 @@ pub enum OpenTagKind {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum TokenKind {
+    HaltCompiler,
     Readonly,
     Global,
     Abstract,
@@ -172,6 +173,7 @@ impl Default for Token {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
+            Self::HaltCompiler => "__halt_compiler",
             Self::Readonly => "readonly",
             Self::AsteriskEqual => "*=",
             Self::ObjectCast => "(object)",

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -170,6 +170,9 @@ impl From<&TokenKind> for IncludeKind {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Statement {
     InlineHtml(ByteString),
+    HaltCompiler {
+        content: Option<ByteString>,
+    },
     Static {
         vars: Vec<StaticVar>,
     },

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -171,6 +171,18 @@ impl Parser {
         self.skip_comments();
 
         let statement = match &self.current.kind {
+            TokenKind::HaltCompiler => {
+                self.next();
+
+                let content = if let TokenKind::InlineHtml(content) = self.current.kind.clone() {
+                    self.next();
+                    Some(content)
+                } else {
+                    None
+                };
+
+                Statement::HaltCompiler { content }
+            }
             TokenKind::Declare => {
                 self.next();
                 self.lparen()?;


### PR DESCRIPTION
Closes #71.

Introduces a new `LexerState::Halted` variant. This will tell the lexer to ensure that the token is followed by `();` same as PHP itself.

It then just collects the rest of the tokens into a single `InlineHtml` token (probably could have done this differently but it works for now) and breaks out of the tokenization loop.