### PR TITLE
parser: add support for static arrow functions

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -460,6 +460,7 @@ pub enum Expression {
         return_type: Option<Type>,
         expr: Box<Self>,
         by_ref: bool,
+        r#static: bool,
     },
     New {
         target: Box<Self>,

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1651,7 +1651,19 @@ impl Parser {
                         by_ref,
                         r#static: true,
                     },
-                    Expression::ArrowFunction { params, return_type, expr, by_ref, .. } => Expression::ArrowFunction { params, return_type, expr, by_ref, r#static: true },
+                    Expression::ArrowFunction {
+                        params,
+                        return_type,
+                        expr,
+                        by_ref,
+                        ..
+                    } => Expression::ArrowFunction {
+                        params,
+                        return_type,
+                        expr,
+                        by_ref,
+                        r#static: true,
+                    },
                     _ => unreachable!(),
                 }
             }
@@ -3961,15 +3973,16 @@ mod tests {
 
     #[test]
     fn static_arrow_functions() {
-        assert_ast("<?php static fn () => null;", &[
-            expr!(Expression::ArrowFunction {
+        assert_ast(
+            "<?php static fn () => null;",
+            &[expr!(Expression::ArrowFunction {
                 params: vec![],
                 expr: Box::new(Expression::Null),
                 return_type: None,
                 by_ref: false,
                 r#static: true,
-            })
-        ]);
+            })],
+        );
     }
 
     #[test]

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -3972,6 +3972,20 @@ mod tests {
         ]);
     }
 
+    #[test]
+    fn static_arrow_functions_returning_by_ref() {
+        assert_ast(
+            "<?php static fn &() => null;",
+            &[expr!(Expression::ArrowFunction {
+                params: vec![],
+                expr: Box::new(Expression::Null),
+                return_type: None,
+                by_ref: true,
+                r#static: true,
+            })],
+        );
+    }
+
     fn assert_ast(source: &str, expected: &[Statement]) {
         let mut lexer = Lexer::new(None);
         let tokens = lexer.tokenize(source).unwrap();

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1632,7 +1632,7 @@ impl Parser {
 
                 Expression::Array { items }
             }
-            TokenKind::Static if matches!(self.peek.kind, TokenKind::Function) => {
+            TokenKind::Static if matches!(self.peek.kind, TokenKind::Function | TokenKind::Fn) => {
                 self.next();
 
                 match self.expression(Precedence::Lowest)? {
@@ -1651,6 +1651,7 @@ impl Parser {
                         by_ref,
                         r#static: true,
                     },
+                    Expression::ArrowFunction { params, return_type, expr, by_ref, .. } => Expression::ArrowFunction { params, return_type, expr, by_ref, r#static: true },
                     _ => unreachable!(),
                 }
             }
@@ -1771,6 +1772,7 @@ impl Parser {
                     return_type,
                     expr: Box::new(value),
                     by_ref,
+                    r#static: false,
                 }
             }
             TokenKind::New => {
@@ -3802,6 +3804,7 @@ mod tests {
                 return_type: None,
                 expr: Box::new(Expression::Null),
                 by_ref: false,
+                r#static: false,
             })],
         );
     }
@@ -3886,6 +3889,7 @@ mod tests {
                 return_type: None,
                 expr: Box::new(Expression::Null),
                 by_ref: false,
+                r#static: false,
             })],
         );
     }
@@ -3950,8 +3954,22 @@ mod tests {
                 expr: Box::new(Expression::Null),
                 return_type: None,
                 by_ref: true,
+                r#static: false,
             })],
         );
+    }
+
+    #[test]
+    fn static_arrow_functions() {
+        assert_ast("<?php static fn () => null;", &[
+            expr!(Expression::ArrowFunction {
+                params: vec![],
+                expr: Box::new(Expression::Null),
+                return_type: None,
+                by_ref: false,
+                r#static: true,
+            })
+        ]);
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {


### PR DESCRIPTION
Related to #69 and #74.

Missed support for `static fn () => null` and added test case for both the basic version and the version that returns a reference.