### PR TITLE
parser: support first class callables on functions

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -414,6 +414,7 @@ pub struct Use {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
     Empty,
+    VariadicPlaceholder,
     ErrorSuppress {
         expr: Box<Self>,
     },

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -2032,7 +2032,7 @@ impl Parser {
                         args.push(Arg {
                             name: None,
                             unpack: false,
-                            value: Expression::VariadicPlaceholder
+                            value: Expression::VariadicPlaceholder,
                         });
 
                         break;
@@ -2114,9 +2114,9 @@ impl Parser {
                                 args.push(Arg {
                                     name: None,
                                     unpack: false,
-                                    value: Expression::VariadicPlaceholder
+                                    value: Expression::VariadicPlaceholder,
                                 });
-    
+
                                 break;
                             }
 
@@ -2180,12 +2180,12 @@ impl Parser {
                             self.next();
                             unpack = true;
                         }
-                        
+
                         if unpack && self.current.kind == TokenKind::RightParen {
                             args.push(Arg {
                                 name: None,
                                 unpack: false,
-                                value: Expression::VariadicPlaceholder
+                                value: Expression::VariadicPlaceholder,
                             });
 
                             break;
@@ -4031,41 +4031,51 @@ mod tests {
 
     #[test]
     fn first_class_callables() {
-        assert_ast("<?php foo(...);", &[
-            expr!(Expression::Call { target: Box::new(Expression::Identifier { name: "foo".into() }), args: vec![
-                Arg {
+        assert_ast(
+            "<?php foo(...);",
+            &[expr!(Expression::Call {
+                target: Box::new(Expression::Identifier { name: "foo".into() }),
+                args: vec![Arg {
                     name: None,
                     unpack: false,
                     value: Expression::VariadicPlaceholder
-                }
-            ] })
-        ]);
+                }]
+            })],
+        );
     }
 
     #[test]
     fn first_class_callable_method() {
-        assert_ast("<?php $this->foo(...);", &[
-            expr!(Expression::MethodCall { target: Box::new(Expression::Variable { name: "this".into() }), method: Box::new(Expression::Identifier { name: "foo".into() }), args: vec![
-                Arg {
+        assert_ast(
+            "<?php $this->foo(...);",
+            &[expr!(Expression::MethodCall {
+                target: Box::new(Expression::Variable {
+                    name: "this".into()
+                }),
+                method: Box::new(Expression::Identifier { name: "foo".into() }),
+                args: vec![Arg {
                     name: None,
                     unpack: false,
                     value: Expression::VariadicPlaceholder
-                }
-            ] })
-        ]);
+                }]
+            })],
+        );
     }
 
     #[test]
     fn first_class_callable_static_method() {
-        assert_ast("<?php A::foo(...);", &[
-            expr!(Expression::StaticMethodCall { target: Box::new(Expression::Identifier { name: "A".into() }), method: "foo".into(), args: vec![
-                Arg {
+        assert_ast(
+            "<?php A::foo(...);",
+            &[expr!(Expression::StaticMethodCall {
+                target: Box::new(Expression::Identifier { name: "A".into() }),
+                method: "foo".into(),
+                args: vec![Arg {
                     name: None,
                     unpack: false,
                     value: Expression::VariadicPlaceholder
-                }
-            ] })
-        ]);
+                }]
+            })],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -2028,6 +2028,16 @@ impl Parser {
                         unpack = true;
                     }
 
+                    if unpack && self.current.kind == TokenKind::RightParen {
+                        args.push(Arg {
+                            name: None,
+                            unpack: false,
+                            value: Expression::VariadicPlaceholder
+                        });
+
+                        break;
+                    }
+
                     let value = self.expression(Precedence::Lowest)?;
 
                     args.push(Arg {
@@ -3997,6 +4007,19 @@ mod tests {
                 r#static: true,
             })],
         );
+    }
+
+    #[test]
+    fn first_class_callables() {
+        assert_ast("<?php foo(...);", &[
+            expr!(Expression::Call { target: Box::new(Expression::Identifier { name: "foo".into() }), args: vec![
+                Arg {
+                    name: None,
+                    unpack: false,
+                    value: Expression::VariadicPlaceholder
+                }
+            ] })
+        ]);
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -2110,6 +2110,16 @@ impl Parser {
                                 unpack = true;
                             }
 
+                            if unpack && self.current.kind == TokenKind::RightParen {
+                                args.push(Arg {
+                                    name: None,
+                                    unpack: false,
+                                    value: Expression::VariadicPlaceholder
+                                });
+    
+                                break;
+                            }
+
                             let value = self.expression(Precedence::Lowest)?;
 
                             args.push(Arg {
@@ -4036,6 +4046,19 @@ mod tests {
     fn first_class_callable_method() {
         assert_ast("<?php $this->foo(...);", &[
             expr!(Expression::MethodCall { target: Box::new(Expression::Variable { name: "this".into() }), method: Box::new(Expression::Identifier { name: "foo".into() }), args: vec![
+                Arg {
+                    name: None,
+                    unpack: false,
+                    value: Expression::VariadicPlaceholder
+                }
+            ] })
+        ]);
+    }
+
+    #[test]
+    fn first_class_callable_static_method() {
+        assert_ast("<?php A::foo(...);", &[
+            expr!(Expression::StaticMethodCall { target: Box::new(Expression::Identifier { name: "A".into() }), method: "foo".into(), args: vec![
                 Arg {
                     name: None,
                     unpack: false,

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -2170,6 +2170,16 @@ impl Parser {
                             self.next();
                             unpack = true;
                         }
+                        
+                        if unpack && self.current.kind == TokenKind::RightParen {
+                            args.push(Arg {
+                                name: None,
+                                unpack: false,
+                                value: Expression::VariadicPlaceholder
+                            });
+
+                            break;
+                        }
 
                         let value = self.expression(Precedence::Lowest)?;
 
@@ -4013,6 +4023,19 @@ mod tests {
     fn first_class_callables() {
         assert_ast("<?php foo(...);", &[
             expr!(Expression::Call { target: Box::new(Expression::Identifier { name: "foo".into() }), args: vec![
+                Arg {
+                    name: None,
+                    unpack: false,
+                    value: Expression::VariadicPlaceholder
+                }
+            ] })
+        ]);
+    }
+
+    #[test]
+    fn first_class_callable_method() {
+        assert_ast("<?php $this->foo(...);", &[
+            expr!(Expression::MethodCall { target: Box::new(Expression::Variable { name: "this".into() }), method: Box::new(Expression::Identifier { name: "foo".into() }), args: vec![
                 Arg {
                     name: None,
                     unpack: false,


### PR DESCRIPTION
Closes #73.

I'm making the decision to not keep functionality inline with PHP-Parser in this case - something like `new Foo(...)` just doesn't make sense syntactically or functionally. In these cases, I'm happy to build a better parser.

On the `$this?->foo(...)` front, we don't actually support nullsafe method calls right now. I've opened #84 to cover that.