### PR TITLE
parser: support `null`/`true`/`false` as a type

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -10,6 +10,7 @@ pub enum Type {
     Union(Vec<ByteString>),
     Intersection(Vec<ByteString>),
     Void,
+    Null,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -12,6 +12,7 @@ pub enum Type {
     Void,
     Null,
     True,
+    False,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -11,6 +11,7 @@ pub enum Type {
     Intersection(Vec<ByteString>),
     Void,
     Null,
+    True,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/trunk_parser/src/parser/ident.rs
+++ b/trunk_parser/src/parser/ident.rs
@@ -61,7 +61,7 @@ impl Parser {
                 let str = self.current.kind.to_string();
                 self.next();
                 str.into()
-            },
+            }
             _ => self.full_name_maybe_type_keyword()?,
         })
     }

--- a/trunk_parser/src/parser/ident.rs
+++ b/trunk_parser/src/parser/ident.rs
@@ -57,10 +57,11 @@ impl Parser {
 
     pub(crate) fn type_with_static(&mut self) -> ParseResult<ByteString> {
         Ok(match self.current.kind {
-            TokenKind::Static => {
+            TokenKind::Static | TokenKind::Null | TokenKind::True | TokenKind::False => {
+                let str = self.current.kind.to_string();
                 self.next();
-                "static".into()
-            }
+                str.into()
+            },
             _ => self.full_name_maybe_type_keyword()?,
         })
     }

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -163,6 +163,7 @@ impl Parser {
 
         Ok(match &id[..] {
             b"void" => Type::Void,
+            b"null" => Type::Null,
             _ => Type::Plain(id),
         })
     }
@@ -4102,6 +4103,13 @@ mod tests {
     #[test]
     fn label() {
         assert_ast("<?php a:", &[Statement::Label { label: "a".into() }]);
+    }
+
+    #[test]
+    fn null_return_type() {
+        assert_ast("<?php function a(): null {}", &[
+            Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::Null), by_ref: false }
+        ]);
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -165,6 +165,7 @@ impl Parser {
             b"void" => Type::Void,
             b"null" => Type::Null,
             b"true" => Type::True,
+            b"false" => Type::False,
             _ => Type::Plain(id),
         })
     }
@@ -4117,6 +4118,13 @@ mod tests {
     fn true_return_type() {
         assert_ast("<?php function a(): true {}", &[
             Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::True), by_ref: false }
+        ]);
+    }
+
+    #[test]
+    fn false_return_type() {
+        assert_ast("<?php function a(): false {}", &[
+            Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::False), by_ref: false }
         ]);
     }
 

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -164,6 +164,7 @@ impl Parser {
         Ok(match &id[..] {
             b"void" => Type::Void,
             b"null" => Type::Null,
+            b"true" => Type::True,
             _ => Type::Plain(id),
         })
     }
@@ -4109,6 +4110,13 @@ mod tests {
     fn null_return_type() {
         assert_ast("<?php function a(): null {}", &[
             Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::Null), by_ref: false }
+        ]);
+    }
+
+    #[test]
+    fn true_return_type() {
+        assert_ast("<?php function a(): true {}", &[
+            Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::True), by_ref: false }
         ]);
     }
 

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -4109,23 +4109,44 @@ mod tests {
 
     #[test]
     fn null_return_type() {
-        assert_ast("<?php function a(): null {}", &[
-            Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::Null), by_ref: false }
-        ]);
+        assert_ast(
+            "<?php function a(): null {}",
+            &[Statement::Function {
+                name: "a".into(),
+                params: vec![],
+                body: vec![],
+                return_type: Some(Type::Null),
+                by_ref: false,
+            }],
+        );
     }
 
     #[test]
     fn true_return_type() {
-        assert_ast("<?php function a(): true {}", &[
-            Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::True), by_ref: false }
-        ]);
+        assert_ast(
+            "<?php function a(): true {}",
+            &[Statement::Function {
+                name: "a".into(),
+                params: vec![],
+                body: vec![],
+                return_type: Some(Type::True),
+                by_ref: false,
+            }],
+        );
     }
 
     #[test]
     fn false_return_type() {
-        assert_ast("<?php function a(): false {}", &[
-            Statement::Function { name: "a".into(), params: vec![], body: vec![], return_type: Some(Type::False), by_ref: false }
-        ]);
+        assert_ast(
+            "<?php function a(): false {}",
+            &[Statement::Function {
+                name: "a".into(),
+                params: vec![],
+                body: vec![],
+                return_type: Some(Type::False),
+                by_ref: false,
+            }],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {


### PR DESCRIPTION
Related to #32.

Have added dedicated `Type` variants for all three since they're special cases. There's also no PHP version specific logic here.