### PR TITLE
lexer: implement all string escape sequences

### DIFF
--- a/trunk_lexer/src/token.rs
+++ b/trunk_lexer/src/token.rs
@@ -156,7 +156,7 @@ pub enum TokenKind {
     While,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     pub kind: TokenKind,
     pub span: Span,


### PR DESCRIPTION
This re-works the string lexing and implements all escape sequences. It also now returns an error for unterminated strings.

Fixes #21