### PR TITLE
parser/lexer: support braced variables

### DIFF
--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -1070,7 +1070,10 @@ function"#,
 
     #[test]
     fn sigils() {
-        assert_tokens("<?php -> $", &[open!(), TokenKind::Arrow, TokenKind::Dollar]);
+        assert_tokens(
+            "<?php -> $",
+            &[open!(), TokenKind::Arrow, TokenKind::Dollar],
+        );
     }
 
     #[test]

--- a/trunk_lexer/src/lexer.rs
+++ b/trunk_lexer/src/lexer.rs
@@ -663,7 +663,11 @@ impl Lexer {
             }
         }
 
-        TokenKind::Variable(buffer.into())
+        if buffer.is_empty() {
+            TokenKind::Dollar
+        } else {
+            TokenKind::Variable(buffer.into())
+        }
     }
 
     fn tokenize_number(
@@ -1066,7 +1070,7 @@ function"#,
 
     #[test]
     fn sigils() {
-        assert_tokens("<?php ->", &[open!(), TokenKind::Arrow]);
+        assert_tokens("<?php -> $", &[open!(), TokenKind::Arrow, TokenKind::Dollar]);
     }
 
     #[test]

--- a/trunk_lexer/src/token.rs
+++ b/trunk_lexer/src/token.rs
@@ -11,6 +11,7 @@ pub enum OpenTagKind {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum TokenKind {
+    Dollar,
     HaltCompiler,
     Readonly,
     Global,
@@ -174,6 +175,7 @@ impl Default for Token {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
+            Self::Dollar => "$",
             Self::HaltCompiler => "__halt_compiler",
             Self::Readonly => "readonly",
             Self::AsteriskEqual => "*=",

--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -442,6 +442,9 @@ pub enum Expression {
     Variable {
         name: ByteString,
     },
+    DynamicVariable {
+        name: Box<Self>,
+    },
     Infix {
         lhs: Box<Self>,
         op: InfixOp,

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -1929,7 +1929,7 @@ impl Parser {
                 let rhs = self.expression(rpred)?;
 
                 prefix(&op, rhs)
-            },
+            }
             TokenKind::Dollar => {
                 self.next();
 
@@ -1941,11 +1941,13 @@ impl Parser {
 
                         self.rbrace()?;
 
-                        Expression::DynamicVariable { name: Box::new(name) }
-                    },
+                        Expression::DynamicVariable {
+                            name: Box::new(name),
+                        }
+                    }
                     _ => todo!(),
                 }
-            },
+            }
             _ => todo!(
                 "expr lhs: {:?}, line {} col {}",
                 self.current.kind,
@@ -4218,11 +4220,24 @@ mod tests {
 
     #[test]
     fn braced_variables() {
-        assert_ast("<?php ${'foo'};", &[
-            expr!(Expression::DynamicVariable {
-                name: Box::new(Expression::ConstantString { value: "foo".into() })
-            })
-        ]);
+        assert_ast(
+            "<?php ${'foo'};",
+            &[expr!(Expression::DynamicVariable {
+                name: Box::new(Expression::ConstantString {
+                    value: "foo".into()
+                })
+            })],
+        );
+
+        assert_ast(
+            "<?php ${foo()};",
+            &[expr!(Expression::DynamicVariable {
+                name: Box::new(Expression::Call {
+                    target: Box::new(Expression::Identifier { name: "foo".into() }),
+                    args: vec![]
+                })
+            })],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {


### PR DESCRIPTION
Closes #77.

Introduces a new `Expression::DynamicVariable` variant that will also be used for `$$foo` too.