### PR TITLE
parser: fix new expressions being parsed incorrectly

### DIFF
--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -4408,9 +4408,13 @@ mod tests {
 
     #[test]
     fn basic_new() {
-        assert_ast("<?php new Foo();", &[
-            expr!(Expression::New { target: Box::new(Expression::Identifier { name: "Foo".into() }), args: vec![] })
-        ]);
+        assert_ast(
+            "<?php new Foo();",
+            &[expr!(Expression::New {
+                target: Box::new(Expression::Identifier { name: "Foo".into() }),
+                args: vec![]
+            })],
+        );
     }
 
     fn assert_ast(source: &str, expected: &[Statement]) {

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -4406,6 +4406,13 @@ mod tests {
         );
     }
 
+    #[test]
+    fn basic_new() {
+        assert_ast("<?php new Foo();", &[
+            expr!(Expression::New { target: Box::new(Expression::Identifier { name: "Foo".into() }), args: vec![] })
+        ]);
+    }
+
     fn assert_ast(source: &str, expected: &[Statement]) {
         let mut lexer = Lexer::new(None);
         let tokens = lexer.tokenize(source).unwrap();

--- a/trunk_parser/src/parser/precedence.rs
+++ b/trunk_parser/src/parser/precedence.rs
@@ -29,9 +29,9 @@ pub enum Precedence {
     Instanceof,
     Prefix,
     Pow,
-    CloneNew,
     CallDim,
     ObjectAccess,
+    CloneNew,
 }
 
 impl Precedence {


### PR DESCRIPTION
After the precedence changes, `new Foo()` was being parsed as `(new (call Foo))` instead of `(new Foo)`.