### PR TITLE
Parse interpolated strings

### DIFF
--- a/trunk_parser/src/ast.rs
+++ b/trunk_parser/src/ast.rs
@@ -487,6 +487,9 @@ pub enum Expression {
     ConstantString {
         value: ByteString,
     },
+    InterpolatedString {
+        parts: Vec<StringPart>,
+    },
     PropertyFetch {
         target: Box<Self>,
         property: Box<Self>,
@@ -609,6 +612,12 @@ pub struct MatchArm {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum MagicConst {
     Dir,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum StringPart {
+    Const(ByteString),
+    Expr(Box<Expression>),
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
I've gone with a pretty simple AST representation, where there are just two parts to strings: constant and expression.

This does lose some information if we want to support AST-rewriting as a use case, since these all parse to the same thing:

```
"$foo"
"{$foo}"
"${foo}"
```

They do the same thing at runtime, though. (You can come up with similar examples for array indexing and property fetching.)

I'm not sure what the philosophy is here, and whether it's something we want to try to get right now or are happy to put off to later.

Fixes #97. (I'll file another issue to mention the few corner cases I'm aware of.)