### PR TITLE
Add precedence for shorthand ternary operator

### DIFF
--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -2783,6 +2783,19 @@ mod tests {
                 r#else: Box::new(Expression::Int { i: 5 }),
             })],
         );
+
+        assert_ast(
+            "<?php 1 ?: 2 ?: 3;",
+            &[expr!(Expression::Ternary {
+                condition: Box::new(Expression::Int { i: 1 }),
+                then: None,
+                r#else: Box::new(Expression::Ternary {
+                    condition: Box::new(Expression::Int { i: 2 }),
+                    then: None,
+                    r#else: Box::new(Expression::Int { i: 3 })
+                }),
+            })],
+        );
     }
 
     #[test]

--- a/trunk_parser/src/parser/precedence.rs
+++ b/trunk_parser/src/parser/precedence.rs
@@ -64,7 +64,7 @@ impl Precedence {
             BooleanAnd => Self::And,
             BooleanOr => Self::Or,
             Coalesce => Self::NullCoalesce,
-            Question => Self::Ternary,
+            Question | QuestionColon => Self::Ternary,
             Equals | PlusEquals | MinusEquals | AsteriskEqual | PowEquals | SlashEquals
             | DotEquals | AndEqual | CoalesceEqual | PercentEquals | AmpersandEquals
             | PipeEquals | CaretEquals | LeftShiftEquals | RightShiftEquals => Self::Assignment,


### PR DESCRIPTION
This was missing and meant shorthand ternary didn't parse.