### PR TITLE
parser: implement DNF types

### DIFF
--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -50,8 +50,8 @@ mod ident;
 mod params;
 mod precedence;
 mod punc;
-mod vars;
 mod types;
+mod vars;
 
 pub struct ParserConfig {
     force_type_strings: bool,

--- a/trunk_parser/src/parser/mod.rs
+++ b/trunk_parser/src/parser/mod.rs
@@ -51,6 +51,7 @@ mod params;
 mod precedence;
 mod punc;
 mod vars;
+mod types;
 
 pub struct ParserConfig {
     force_type_strings: bool,
@@ -113,62 +114,6 @@ impl Parser {
         }
 
         Ok(ast.to_vec())
-    }
-
-    fn type_string(&mut self) -> ParseResult<Type> {
-        if self.current.kind == TokenKind::Question {
-            self.next();
-            let t = self.type_with_static()?;
-            return Ok(Type::Nullable(t));
-        }
-
-        let id = self.type_with_static()?;
-
-        if self.current.kind == TokenKind::Pipe {
-            self.next();
-
-            let mut types = vec![id];
-
-            while !self.is_eof() {
-                let id = self.type_with_static()?;
-                types.push(id);
-
-                if self.current.kind != TokenKind::Pipe {
-                    break;
-                } else {
-                    self.next();
-                }
-            }
-
-            return Ok(Type::Union(types));
-        }
-
-        if self.current.kind == TokenKind::Ampersand {
-            self.next();
-
-            let mut types = vec![id];
-
-            while !self.is_eof() {
-                let id = self.type_with_static()?;
-                types.push(id);
-
-                if self.current.kind != TokenKind::Ampersand {
-                    break;
-                } else {
-                    self.next();
-                }
-            }
-
-            return Ok(Type::Intersection(types));
-        }
-
-        Ok(match &id[..] {
-            b"void" => Type::Void,
-            b"null" => Type::Null,
-            b"true" => Type::True,
-            b"false" => Type::False,
-            _ => Type::Plain(id),
-        })
     }
 
     fn top_level_statement(&mut self) -> ParseResult<Statement> {

--- a/trunk_parser/src/parser/types.rs
+++ b/trunk_parser/src/parser/types.rs
@@ -1,6 +1,6 @@
-use crate::Parser;
 use super::{ParseResult, Type};
-use trunk_lexer::{TokenKind};
+use crate::Parser;
+use trunk_lexer::TokenKind;
 
 impl Parser {
     pub(crate) fn type_string(&mut self) -> ParseResult<Type> {

--- a/trunk_parser/src/parser/types.rs
+++ b/trunk_parser/src/parser/types.rs
@@ -1,0 +1,61 @@
+use crate::Parser;
+use super::{ParseResult, Type};
+use trunk_lexer::{TokenKind};
+
+impl Parser {
+    pub(crate) fn type_string(&mut self) -> ParseResult<Type> {
+        if self.current.kind == TokenKind::Question {
+            self.next();
+            let t = self.type_with_static()?;
+            return Ok(Type::Nullable(t));
+        }
+
+        let id = self.type_with_static()?;
+
+        if self.current.kind == TokenKind::Pipe {
+            self.next();
+
+            let mut types = vec![id];
+
+            while !self.is_eof() {
+                let id = self.type_with_static()?;
+                types.push(id);
+
+                if self.current.kind != TokenKind::Pipe {
+                    break;
+                } else {
+                    self.next();
+                }
+            }
+
+            return Ok(Type::Union(types));
+        }
+
+        if self.current.kind == TokenKind::Ampersand {
+            self.next();
+
+            let mut types = vec![id];
+
+            while !self.is_eof() {
+                let id = self.type_with_static()?;
+                types.push(id);
+
+                if self.current.kind != TokenKind::Ampersand {
+                    break;
+                } else {
+                    self.next();
+                }
+            }
+
+            return Ok(Type::Intersection(types));
+        }
+
+        Ok(match &id[..] {
+            b"void" => Type::Void,
+            b"null" => Type::Null,
+            b"true" => Type::True,
+            b"false" => Type::False,
+            _ => Type::Plain(id),
+        })
+    }
+}


### PR DESCRIPTION
Closes #32.

This PR implements the missing DNF types implemented in PHP 8.2.